### PR TITLE
GitHub Actions CI에서 기존 unittest 자동 실행

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests (Python 3.11)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m unittest discover -s tests -p "test_*.py" -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -113,7 +113,7 @@ pyparsing==3.2.5
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 python-json-logger==4.0.0
-pywinpty==3.0.2
+pywinpty==3.0.2; platform_system == "Windows"
 PyYAML==6.0.3
 pyzmq==27.1.0
 referencing==0.37.0


### PR DESCRIPTION
## 🔗 관련 이슈

#19 

## 📝 작업 내용

- GitHub Actions CI 워크플로우 추가
- Pull Request 및 main 브랜치 push 시 자동 실행
- Python 3.11 환경에서 테스트 실행
- 기존 `unittest` 테스트 자동 실행
