### PR TITLE
AWS 프로비저닝 스크립트의 MSYS 경로 변환 방지

### DIFF
--- a/deploy/monitoring/provision-aws.sh
+++ b/deploy/monitoring/provision-aws.sh
@@ -2,6 +2,14 @@
 # AWS 쪽 모니터링 리소스와 장애 이메일 알림을 자동으로 구성하는 스크립트
 set -euo pipefail
 
+# Prevent Git Bash/MSYS from converting AWS resource names such as
+# /sjseed/ai/docker into Windows filesystem paths.
+case "${MSYSTEM:-}" in
+  MINGW*|MSYS*)
+    export MSYS2_ARG_CONV_EXCL='*'
+    ;;
+esac
+
 AWS_REGION="${AWS_REGION:-ap-northeast-2}"
 INSTANCE_ID="${INSTANCE_ID:-}"
 ALERT_EMAIL="${ALERT_EMAIL:-}"


### PR DESCRIPTION
## 📝 작업 내용

Windows Git Bash/MSYS 환경에서 /sjseed/ai/docker와 같은 AWS 리소스 이름이 Windows 파일 경로로 자동 변환되는 문제를 수정
MINGW 또는 MSYS 환경에서만 MSYS 인자 변환을 비활성화하도록 설정
