### PR TITLE
CD 마이그레이션의 표준 입력 소비 방지

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -100,7 +100,7 @@ jobs:
 
             docker compose pull ai worker
             docker compose up -d postgres
-            docker compose run --rm ai alembic upgrade head
+            docker compose run --rm --no-deps -T ai alembic upgrade head </dev/null
             docker compose up -d --no-build --force-recreate ai worker
 
             expected_image_id="$(docker image inspect ghcr.io/sj-seed/ai:latest --format '{{.Id}}')"


### PR DESCRIPTION
## 📝 작업 내용

## 변경 사항

- Alembic 실행이 SSH heredoc의 이후 배포 명령을 표준 입력으로 소비하지 않도록 수정
- 비대화형 실행을 위해 `-T` 적용
- 불필요한 의존 서비스 실행 방지를 위해 `--no-deps` 적용