### PR TITLE
분석 작업 자동 삭제

### DIFF
--- a/alembic/versions/f9c3a7d2e641_add_analysis_cleanup_index.py
+++ b/alembic/versions/f9c3a7d2e641_add_analysis_cleanup_index.py
@@ -1,0 +1,31 @@
+"""add analysis cleanup index
+
+Revision ID: f9c3a7d2e641
+Revises: 8b31d6a950f2
+Create Date: 2026-08-16
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f9c3a7d2e641"
+down_revision: Union[str, Sequence[str], None] = "8b31d6a950f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_analyses_terminal_completed_at",
+        "analyses",
+        ["completed_at"],
+        unique=False,
+        postgresql_where=sa.text("status IN ('COMPLETED', 'FAILED')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_analyses_terminal_completed_at", table_name="analyses")

--- a/alembic/versions/f9c3a7d2e641_add_analysis_cleanup_index.py
+++ b/alembic/versions/f9c3a7d2e641_add_analysis_cleanup_index.py
@@ -18,14 +18,21 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.create_index(
-        "ix_analyses_terminal_completed_at",
-        "analyses",
-        ["completed_at"],
-        unique=False,
-        postgresql_where=sa.text("status IN ('COMPLETED', 'FAILED')"),
-    )
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_analyses_terminal_completed_at",
+            "analyses",
+            ["completed_at"],
+            unique=False,
+            postgresql_where=sa.text("status IN ('COMPLETED', 'FAILED')"),
+            postgresql_concurrently=True,
+        )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_analyses_terminal_completed_at", table_name="analyses")
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_analyses_terminal_completed_at",
+            table_name="analyses",
+            postgresql_concurrently=True,
+        )

--- a/app/application/ports/analysis_repository.py
+++ b/app/application/ports/analysis_repository.py
@@ -65,6 +65,10 @@ class AnalysisRepository(Protocol):
         """Release a reconciliation claim after an enqueue error."""
         ...
 
+    async def delete_terminal_before(self, cutoff: datetime) -> int:
+        """Delete completed or failed analyses completed at or before cutoff."""
+        ...
+
     # 분석이 정상적으로 끝났을 떄 결과를 저장하고 COMPLETED 상태로 변경
     async def mark_completed(
         self,

--- a/app/infrastructure/persistence/analysis_repository.py
+++ b/app/infrastructure/persistence/analysis_repository.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 
-from sqlalchemy import and_, func, or_, select, update
+from sqlalchemy import and_, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.application.ports.analysis_repository import AnalysisRepository
@@ -190,6 +190,20 @@ class SqlAlchemyAnalysisRepository(AnalysisRepository):
             .values(enqueue_claimed_at=None)
         )
         return await self._execute_transition(statement)
+
+    async def delete_terminal_before(self, cutoff: datetime) -> int:
+        """Delete terminal analyses whose completion timestamp reached the cutoff."""
+        statement = delete(Analysis).where(
+            Analysis.status.in_((AnalysisStatus.COMPLETED, AnalysisStatus.FAILED)),
+            Analysis.completed_at <= cutoff,
+        )
+        try:
+            result = await self.session.execute(statement)
+            await self.session.commit()
+            return int(result.rowcount)
+        except Exception:
+            await self.session.rollback()
+            raise
 
     # 분석이 성공적으로 완료되었을 때 결과 저장
     async def mark_completed(

--- a/app/worker/settings.py
+++ b/app/worker/settings.py
@@ -4,7 +4,13 @@ from app.core.config import load_settings, require_redis_url
 from app.infrastructure.queue.redis_settings import build_redis_settings
 from arq import cron
 
-from app.worker.tasks import process_analysis, reconcile_pending_analyses, shutdown, startup
+from app.worker.tasks import (
+    cleanup_terminal_analyses,
+    process_analysis,
+    reconcile_pending_analyses,
+    shutdown,
+    startup,
+)
 
 
 # Worker 프로세스 시작 시 환경변수와 애플리케이션 설정 로드
@@ -18,7 +24,10 @@ class WorkerSettings:
     functions = [process_analysis]
 
     # Queue 등록이 확인되지 않은 오래된 PENDING 작업을 매분 복구
-    cron_jobs = [cron(reconcile_pending_analyses, second=0)]
+    cron_jobs = [
+        cron(reconcile_pending_analyses, second=0),
+        cron(cleanup_terminal_analyses, minute=0, second=0),
+    ]
 
     # Worker 시작 시 DB, OpenAI 및 AI 모델 자원을 초기화하는 함수
     on_startup = startup

--- a/app/worker/tasks.py
+++ b/app/worker/tasks.py
@@ -37,6 +37,7 @@ AI_ANALYSIS_ERROR = "AI_ANALYSIS_ERROR"
 AI_AUTHENTICATION_ERROR = "AI_AUTHENTICATION_ERROR"
 WORKER_INTERNAL_ERROR = "WORKER_INTERNAL_ERROR"
 MAX_PERSISTED_ERROR_MESSAGE_LENGTH = 255
+ANALYSIS_RETENTION = timedelta(hours=24)
 
 # 실제 예외 내용 대신 DB에 저장할 안전한 고정 메시지
 SAFE_ERROR_MESSAGES = {
@@ -195,6 +196,22 @@ async def reconcile_pending_analyses(ctx: dict[str, Any]) -> int:
             )
 
     return enqueued_count
+
+
+async def cleanup_terminal_analyses(ctx: dict[str, Any]) -> int:
+    """Delete completed and failed analyses after the retention period."""
+    cutoff = datetime.now(timezone.utc) - ANALYSIS_RETENTION
+    session_factory = ctx["session_factory"]
+
+    async with session_factory() as session:
+        repository = SqlAlchemyAnalysisRepository(session)
+        deleted_count = await repository.delete_terminal_before(cutoff)
+
+    logger.info(
+        "Cleaned up expired analysis jobs",
+        extra={"deleted_count": deleted_count, "cutoff": cutoff.isoformat()},
+    )
+    return deleted_count
 
 
 async def process_analysis(ctx: dict[str, Any], analysis_id: int) -> bool:

--- a/tests/unit/test_analysis_repository.py
+++ b/tests/unit/test_analysis_repository.py
@@ -289,6 +289,59 @@ class AnalysisRepositoryTest(unittest.TestCase):
                 self.session.commit.assert_not_awaited()
                 self.session.rollback.assert_awaited_once_with()
 
+    def test_delete_terminal_before_deletes_only_expired_terminal_analyses(self):
+        self._set_rowcounts(3)
+        cutoff = datetime(2026, 8, 15, 12, 0, tzinfo=timezone.utc)
+
+        deleted_count = asyncio.run(
+            self.repository.delete_terminal_before(cutoff)
+        )
+
+        self.assertEqual(deleted_count, 3)
+        statement = self.session.execute.await_args.args[0]
+        sql = str(statement.compile(dialect=postgresql.dialect()))
+        params = statement.compile().params
+        self.assertIn("DELETE FROM analyses", sql)
+        self.assertIn("analyses.status IN", sql)
+        self.assertIn("analyses.completed_at <=", sql)
+        self.assertIn(
+            [AnalysisStatus.COMPLETED, AnalysisStatus.FAILED],
+            params.values(),
+        )
+        self.assertIn(cutoff, params.values())
+        self.session.commit.assert_awaited_once_with()
+        self.session.rollback.assert_not_awaited()
+
+    def test_delete_terminal_before_rolls_back_on_execute_error(self):
+        error = RuntimeError("delete failed")
+        self.session.execute.side_effect = error
+
+        with self.assertRaises(RuntimeError) as raised:
+            asyncio.run(
+                self.repository.delete_terminal_before(
+                    datetime(2026, 8, 15, tzinfo=timezone.utc)
+                )
+            )
+
+        self.assertIs(raised.exception, error)
+        self.session.rollback.assert_awaited_once_with()
+        self.session.commit.assert_not_awaited()
+
+    def test_delete_terminal_before_rolls_back_on_commit_error(self):
+        self._set_rowcounts(1)
+        error = RuntimeError("commit failed")
+        self.session.commit.side_effect = error
+
+        with self.assertRaises(RuntimeError) as raised:
+            asyncio.run(
+                self.repository.delete_terminal_before(
+                    datetime(2026, 8, 15, tzinfo=timezone.utc)
+                )
+            )
+
+        self.assertIs(raised.exception, error)
+        self.session.rollback.assert_awaited_once_with()
+
     def test_execute_error_rolls_back_and_propagates(self):
         error = RuntimeError("execute failed")
         self.session.execute.side_effect = error

--- a/tests/unit/test_worker_settings.py
+++ b/tests/unit/test_worker_settings.py
@@ -24,6 +24,13 @@ class WorkerSettingsTest(unittest.TestCase):
         self.assertEqual(settings.max_jobs, 1)
         self.assertEqual(settings.max_tries, 5)
         self.assertTrue(settings.retry_jobs)
+        self.assertEqual(
+            [job.coroutine.__name__ for job in settings.cron_jobs],
+            ["reconcile_pending_analyses", "cleanup_terminal_analyses"],
+        )
+        cleanup_job = settings.cron_jobs[1]
+        self.assertEqual(cleanup_job.minute, 0)
+        self.assertEqual(cleanup_job.second, 0)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_worker_tasks.py
+++ b/tests/unit/test_worker_tasks.py
@@ -15,11 +15,13 @@ from app.infrastructure.image.image_downloader import (
     ImageDownloadResult,
 )
 from app.worker.tasks import (
+    ANALYSIS_RETENTION,
     AI_ANALYSIS_ERROR,
     IMAGE_DOWNLOAD_ERROR,
     WORKER_INTERNAL_ERROR,
     ImageDownloadFailure,
     WorkerInternalFailure,
+    cleanup_terminal_analyses,
     process_analysis,
     reconcile_pending_analyses,
     shutdown,
@@ -466,6 +468,36 @@ class ReconciliationTaskTest(unittest.TestCase):
         self.assertEqual(count, 0)
         self.repository.release_enqueue_claim.assert_awaited_once_with(11)
         self.repository.mark_enqueued.assert_not_awaited()
+
+
+class CleanupTaskTest(unittest.TestCase):
+    def setUp(self):
+        self.repository = Mock()
+        self.repository.delete_terminal_before = AsyncMock(return_value=4)
+        self.ctx = {"session_factory": SessionFactory()}
+
+    def test_deletes_jobs_older_than_twenty_four_hours_and_logs_count(self):
+        now = datetime(2026, 8, 16, 15, 30, tzinfo=timezone.utc)
+
+        with patch(
+            "app.worker.tasks.SqlAlchemyAnalysisRepository",
+            return_value=self.repository,
+        ), patch("app.worker.tasks.datetime") as datetime_type, self.assertLogs(
+            "app.worker.tasks", level="INFO"
+        ) as logs:
+            datetime_type.now.return_value = now
+            deleted_count = asyncio.run(cleanup_terminal_analyses(self.ctx))
+
+        self.assertEqual(deleted_count, 4)
+        self.repository.delete_terminal_before.assert_awaited_once_with(
+            now - ANALYSIS_RETENTION
+        )
+        self.assertIn("Cleaned up expired analysis jobs", logs.output[0])
+        self.assertEqual(logs.records[0].deleted_count, 4)
+        self.assertEqual(
+            logs.records[0].cutoff,
+            (now - ANALYSIS_RETENTION).isoformat(),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔗 관련 이슈

#31 

## 📝 작업 내용

- COMPLETED, FAILED: 완료된 지 24시간이 지나면 삭제
- PENDING, PROCESSING: 아직 진행 중이므로 삭제하지 않음
- 매시간 정각에 자동으로 오래된 기록을 검사하고 삭제
- 몇 건을 삭제했는지 로그로 남김
- 삭제 조회가 빠르게 동작하도록 PostgreSQL 인덱스 추가